### PR TITLE
Updated permission names in README and also stopped GetGroups from faili...

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ You can register the app with the Office 365 API Tools for Visual Studio. Be sur
    
    6. To register for the services used in this sample, choose the following services and permissions:
 
- 	- **Calendar** - Have full access to users' calendars.
-	- **Contacts** - Have full access to users' contacts.
-	- **Mail** - Read and write access to users' mail. Send mail as a user.
-	- **My Files** - Edit or delete users' files.
+ 	- **Calendar** - Read and write user calendars.
+	- **Contacts** - Read and write user contacts.
+	- **Mail** - Read and write user mail. Send mail as a user.
+	- **My Files** - Read and write user files.
 	- **Users and Groups** - Enable sign-on and read users' profiles. Access your organization's directory. 
 	
 

--- a/src/UsersAndGroups/UsersAndGroupsSnippets.cs
+++ b/src/UsersAndGroups/UsersAndGroupsSnippets.cs
@@ -131,6 +131,12 @@ namespace O365_Win_Snippets
 
                 var groups = await client.Groups.ExecuteAsync();
 
+                if (groups.CurrentPage.Count == 0)
+                {
+                    Debug.WriteLine("No groups.");
+                    return new List<IGroup>(); 
+                }
+
                 Debug.WriteLine("First group in collection: " + groups.CurrentPage[0].DisplayName);
 
                 return groups.CurrentPage.ToList();


### PR DESCRIPTION
...ng on tenants with 0 groups.

I noticed when I ran all the snippets (which didn't take nearly as long as I thought it would), that the last one fails if there are no groups in the tenant. If that's what you want to happen, reject that change. However, I think saying it failed is incorrect. It read the groups correctly, just wasn't any to return.
